### PR TITLE
/user endpoint implementation

### DIFF
--- a/api/swagger/docs.go
+++ b/api/swagger/docs.go
@@ -47,13 +47,13 @@ const docTemplate = `{
                     "400": {
                         "description": "Bad Request",
                         "schema": {
-                            "$ref": "#/definitions/v1.response"
+                            "$ref": "#/definitions/utils.Response"
                         }
                     },
                     "500": {
                         "description": "Internal Server Error",
                         "schema": {
-                            "$ref": "#/definitions/v1.response"
+                            "$ref": "#/definitions/utils.Response"
                         }
                     }
                 }
@@ -91,25 +91,25 @@ const docTemplate = `{
                     "400": {
                         "description": "Bad Request",
                         "schema": {
-                            "$ref": "#/definitions/v1.response"
+                            "$ref": "#/definitions/utils.Response"
                         }
                     },
                     "404": {
                         "description": "Not Found",
                         "schema": {
-                            "$ref": "#/definitions/v1.response"
+                            "$ref": "#/definitions/utils.Response"
                         }
                     },
                     "500": {
                         "description": "Internal Server Error",
                         "schema": {
-                            "$ref": "#/definitions/v1.response"
+                            "$ref": "#/definitions/utils.Response"
                         }
                     },
                     "default": {
                         "description": "",
                         "schema": {
-                            "$ref": "#/definitions/v1.response"
+                            "$ref": "#/definitions/utils.Response"
                         }
                     }
                 }
@@ -142,7 +142,7 @@ const docTemplate = `{
                 }
             }
         },
-        "v1.response": {
+        "utils.Response": {
             "type": "object",
             "properties": {
                 "message": {

--- a/api/swagger/docs.go
+++ b/api/swagger/docs.go
@@ -114,6 +114,118 @@ const docTemplate = `{
                     }
                 }
             }
+        },
+        "/user/": {
+            "get": {
+                "description": "returns info on the currently logged-in user. User_id is extracted from the bearer token",
+                "consumes": [
+                    "application/json"
+                ],
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "User"
+                ],
+                "summary": "Retrieve current user data",
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "$ref": "#/definitions/service.GetUserInfoOutput"
+                        }
+                    },
+                    "400": {
+                        "description": "Bad Request",
+                        "schema": {
+                            "$ref": "#/definitions/utils.Response"
+                        }
+                    },
+                    "401": {
+                        "description": "Unauthorized",
+                        "schema": {
+                            "$ref": "#/definitions/utils.Response"
+                        }
+                    },
+                    "404": {
+                        "description": "Not Found",
+                        "schema": {
+                            "$ref": "#/definitions/utils.Response"
+                        }
+                    },
+                    "500": {
+                        "description": "Internal Server Error",
+                        "schema": {
+                            "$ref": "#/definitions/utils.Response"
+                        }
+                    },
+                    "default": {
+                        "description": "",
+                        "schema": {
+                            "$ref": "#/definitions/utils.Response"
+                        }
+                    }
+                }
+            },
+            "put": {
+                "description": "modifies user info for the currently logged-in user. User_id is extracted from the bearer token",
+                "consumes": [
+                    "application/json"
+                ],
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "User"
+                ],
+                "summary": "Modify current user data",
+                "parameters": [
+                    {
+                        "description": "user info",
+                        "name": "input",
+                        "in": "body",
+                        "required": true,
+                        "schema": {
+                            "$ref": "#/definitions/service.UpdateUserInfoInput"
+                        }
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK"
+                    },
+                    "400": {
+                        "description": "Bad Request",
+                        "schema": {
+                            "$ref": "#/definitions/utils.Response"
+                        }
+                    },
+                    "401": {
+                        "description": "Unauthorized",
+                        "schema": {
+                            "$ref": "#/definitions/utils.Response"
+                        }
+                    },
+                    "404": {
+                        "description": "Not Found",
+                        "schema": {
+                            "$ref": "#/definitions/utils.Response"
+                        }
+                    },
+                    "500": {
+                        "description": "Internal Server Error",
+                        "schema": {
+                            "$ref": "#/definitions/utils.Response"
+                        }
+                    },
+                    "default": {
+                        "description": "",
+                        "schema": {
+                            "$ref": "#/definitions/utils.Response"
+                        }
+                    }
+                }
+            }
         }
     },
     "definitions": {
@@ -142,6 +254,49 @@ const docTemplate = `{
                 }
             }
         },
+        "service.GetUserInfoOutput": {
+            "type": "object",
+            "properties": {
+                "display_name": {
+                    "type": "string"
+                },
+                "email": {
+                    "type": "string"
+                },
+                "first_name": {
+                    "type": "string"
+                },
+                "id": {
+                    "type": "string"
+                },
+                "last_name": {
+                    "type": "string"
+                },
+                "registration_date": {
+                    "type": "string"
+                },
+                "roles": {
+                    "type": "array",
+                    "items": {
+                        "type": "integer"
+                    }
+                }
+            }
+        },
+        "service.UpdateUserInfoInput": {
+            "type": "object",
+            "properties": {
+                "display_name": {
+                    "type": "string"
+                },
+                "first_name": {
+                    "type": "string"
+                },
+                "last_name": {
+                    "type": "string"
+                }
+            }
+        },
         "utils.Response": {
             "type": "object",
             "properties": {
@@ -151,23 +306,16 @@ const docTemplate = `{
             }
         }
     },
-    "securityDefinitions": {
-        "AdminAuth": {
-            "type": "apiKey",
-            "name": "Authorization",
-            "in": "header"
+    "tags": [
+        {
+            "description": "Managing user account",
+            "name": "User"
         },
-        "StudentsAuth": {
-            "type": "apiKey",
-            "name": "Authorization",
-            "in": "header"
-        },
-        "UsersAuth": {
-            "type": "apiKey",
-            "name": "Authorization",
-            "in": "header"
+        {
+            "description": "Temporary endpoints for Swagger demo. To be removed",
+            "name": "courses"
         }
-    }
+    ]
 }`
 
 // SwaggerInfo holds exported Swagger Info so clients can modify it

--- a/api/swagger/swagger.json
+++ b/api/swagger/swagger.json
@@ -107,6 +107,118 @@
                     }
                 }
             }
+        },
+        "/user/": {
+            "get": {
+                "description": "returns info on the currently logged-in user. User_id is extracted from the bearer token",
+                "consumes": [
+                    "application/json"
+                ],
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "User"
+                ],
+                "summary": "Retrieve current user data",
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "$ref": "#/definitions/service.GetUserInfoOutput"
+                        }
+                    },
+                    "400": {
+                        "description": "Bad Request",
+                        "schema": {
+                            "$ref": "#/definitions/utils.Response"
+                        }
+                    },
+                    "401": {
+                        "description": "Unauthorized",
+                        "schema": {
+                            "$ref": "#/definitions/utils.Response"
+                        }
+                    },
+                    "404": {
+                        "description": "Not Found",
+                        "schema": {
+                            "$ref": "#/definitions/utils.Response"
+                        }
+                    },
+                    "500": {
+                        "description": "Internal Server Error",
+                        "schema": {
+                            "$ref": "#/definitions/utils.Response"
+                        }
+                    },
+                    "default": {
+                        "description": "",
+                        "schema": {
+                            "$ref": "#/definitions/utils.Response"
+                        }
+                    }
+                }
+            },
+            "put": {
+                "description": "modifies user info for the currently logged-in user. User_id is extracted from the bearer token",
+                "consumes": [
+                    "application/json"
+                ],
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "User"
+                ],
+                "summary": "Modify current user data",
+                "parameters": [
+                    {
+                        "description": "user info",
+                        "name": "input",
+                        "in": "body",
+                        "required": true,
+                        "schema": {
+                            "$ref": "#/definitions/service.UpdateUserInfoInput"
+                        }
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK"
+                    },
+                    "400": {
+                        "description": "Bad Request",
+                        "schema": {
+                            "$ref": "#/definitions/utils.Response"
+                        }
+                    },
+                    "401": {
+                        "description": "Unauthorized",
+                        "schema": {
+                            "$ref": "#/definitions/utils.Response"
+                        }
+                    },
+                    "404": {
+                        "description": "Not Found",
+                        "schema": {
+                            "$ref": "#/definitions/utils.Response"
+                        }
+                    },
+                    "500": {
+                        "description": "Internal Server Error",
+                        "schema": {
+                            "$ref": "#/definitions/utils.Response"
+                        }
+                    },
+                    "default": {
+                        "description": "",
+                        "schema": {
+                            "$ref": "#/definitions/utils.Response"
+                        }
+                    }
+                }
+            }
         }
     },
     "definitions": {
@@ -135,6 +247,49 @@
                 }
             }
         },
+        "service.GetUserInfoOutput": {
+            "type": "object",
+            "properties": {
+                "display_name": {
+                    "type": "string"
+                },
+                "email": {
+                    "type": "string"
+                },
+                "first_name": {
+                    "type": "string"
+                },
+                "id": {
+                    "type": "string"
+                },
+                "last_name": {
+                    "type": "string"
+                },
+                "registration_date": {
+                    "type": "string"
+                },
+                "roles": {
+                    "type": "array",
+                    "items": {
+                        "type": "integer"
+                    }
+                }
+            }
+        },
+        "service.UpdateUserInfoInput": {
+            "type": "object",
+            "properties": {
+                "display_name": {
+                    "type": "string"
+                },
+                "first_name": {
+                    "type": "string"
+                },
+                "last_name": {
+                    "type": "string"
+                }
+            }
+        },
         "utils.Response": {
             "type": "object",
             "properties": {
@@ -144,21 +299,14 @@
             }
         }
     },
-    "securityDefinitions": {
-        "AdminAuth": {
-            "type": "apiKey",
-            "name": "Authorization",
-            "in": "header"
+    "tags": [
+        {
+            "description": "Managing user account",
+            "name": "User"
         },
-        "StudentsAuth": {
-            "type": "apiKey",
-            "name": "Authorization",
-            "in": "header"
-        },
-        "UsersAuth": {
-            "type": "apiKey",
-            "name": "Authorization",
-            "in": "header"
+        {
+            "description": "Temporary endpoints for Swagger demo. To be removed",
+            "name": "courses"
         }
-    }
+    ]
 }

--- a/api/swagger/swagger.json
+++ b/api/swagger/swagger.json
@@ -40,13 +40,13 @@
                     "400": {
                         "description": "Bad Request",
                         "schema": {
-                            "$ref": "#/definitions/v1.response"
+                            "$ref": "#/definitions/utils.Response"
                         }
                     },
                     "500": {
                         "description": "Internal Server Error",
                         "schema": {
-                            "$ref": "#/definitions/v1.response"
+                            "$ref": "#/definitions/utils.Response"
                         }
                     }
                 }
@@ -84,25 +84,25 @@
                     "400": {
                         "description": "Bad Request",
                         "schema": {
-                            "$ref": "#/definitions/v1.response"
+                            "$ref": "#/definitions/utils.Response"
                         }
                     },
                     "404": {
                         "description": "Not Found",
                         "schema": {
-                            "$ref": "#/definitions/v1.response"
+                            "$ref": "#/definitions/utils.Response"
                         }
                     },
                     "500": {
                         "description": "Internal Server Error",
                         "schema": {
-                            "$ref": "#/definitions/v1.response"
+                            "$ref": "#/definitions/utils.Response"
                         }
                     },
                     "default": {
                         "description": "",
                         "schema": {
-                            "$ref": "#/definitions/v1.response"
+                            "$ref": "#/definitions/utils.Response"
                         }
                     }
                 }
@@ -135,7 +135,7 @@
                 }
             }
         },
-        "v1.response": {
+        "utils.Response": {
             "type": "object",
             "properties": {
                 "message": {

--- a/api/swagger/swagger.yaml
+++ b/api/swagger/swagger.yaml
@@ -16,7 +16,7 @@ definitions:
       title:
         type: string
     type: object
-  v1.response:
+  utils.Response:
     properties:
       message:
         type: string
@@ -48,11 +48,11 @@ paths:
         "400":
           description: Bad Request
           schema:
-            $ref: '#/definitions/v1.response'
+            $ref: '#/definitions/utils.Response'
         "500":
           description: Internal Server Error
           schema:
-            $ref: '#/definitions/v1.response'
+            $ref: '#/definitions/utils.Response'
       summary: Creates a new Course entity
       tags:
       - courses
@@ -77,19 +77,19 @@ paths:
         "400":
           description: Bad Request
           schema:
-            $ref: '#/definitions/v1.response'
+            $ref: '#/definitions/utils.Response'
         "404":
           description: Not Found
           schema:
-            $ref: '#/definitions/v1.response'
+            $ref: '#/definitions/utils.Response'
         "500":
           description: Internal Server Error
           schema:
-            $ref: '#/definitions/v1.response'
+            $ref: '#/definitions/utils.Response'
         default:
           description: ""
           schema:
-            $ref: '#/definitions/v1.response'
+            $ref: '#/definitions/utils.Response'
       summary: Get Course By course id
       tags:
       - courses

--- a/api/swagger/swagger.yaml
+++ b/api/swagger/swagger.yaml
@@ -16,6 +16,34 @@ definitions:
       title:
         type: string
     type: object
+  service.GetUserInfoOutput:
+    properties:
+      display_name:
+        type: string
+      email:
+        type: string
+      first_name:
+        type: string
+      id:
+        type: string
+      last_name:
+        type: string
+      registration_date:
+        type: string
+      roles:
+        items:
+          type: integer
+        type: array
+    type: object
+  service.UpdateUserInfoInput:
+    properties:
+      display_name:
+        type: string
+      first_name:
+        type: string
+      last_name:
+        type: string
+    type: object
   utils.Response:
     properties:
       message:
@@ -93,17 +121,85 @@ paths:
       summary: Get Course By course id
       tags:
       - courses
-securityDefinitions:
-  AdminAuth:
-    in: header
-    name: Authorization
-    type: apiKey
-  StudentsAuth:
-    in: header
-    name: Authorization
-    type: apiKey
-  UsersAuth:
-    in: header
-    name: Authorization
-    type: apiKey
+  /user/:
+    get:
+      consumes:
+      - application/json
+      description: returns info on the currently logged-in user. User_id is extracted
+        from the bearer token
+      produces:
+      - application/json
+      responses:
+        "200":
+          description: OK
+          schema:
+            $ref: '#/definitions/service.GetUserInfoOutput'
+        "400":
+          description: Bad Request
+          schema:
+            $ref: '#/definitions/utils.Response'
+        "401":
+          description: Unauthorized
+          schema:
+            $ref: '#/definitions/utils.Response'
+        "404":
+          description: Not Found
+          schema:
+            $ref: '#/definitions/utils.Response'
+        "500":
+          description: Internal Server Error
+          schema:
+            $ref: '#/definitions/utils.Response'
+        default:
+          description: ""
+          schema:
+            $ref: '#/definitions/utils.Response'
+      summary: Retrieve current user data
+      tags:
+      - User
+    put:
+      consumes:
+      - application/json
+      description: modifies user info for the currently logged-in user. User_id is
+        extracted from the bearer token
+      parameters:
+      - description: user info
+        in: body
+        name: input
+        required: true
+        schema:
+          $ref: '#/definitions/service.UpdateUserInfoInput'
+      produces:
+      - application/json
+      responses:
+        "200":
+          description: OK
+        "400":
+          description: Bad Request
+          schema:
+            $ref: '#/definitions/utils.Response'
+        "401":
+          description: Unauthorized
+          schema:
+            $ref: '#/definitions/utils.Response'
+        "404":
+          description: Not Found
+          schema:
+            $ref: '#/definitions/utils.Response'
+        "500":
+          description: Internal Server Error
+          schema:
+            $ref: '#/definitions/utils.Response'
+        default:
+          description: ""
+          schema:
+            $ref: '#/definitions/utils.Response'
+      summary: Modify current user data
+      tags:
+      - User
 swagger: "2.0"
+tags:
+- description: Managing user account
+  name: User
+- description: Temporary endpoints for Swagger demo. To be removed
+  name: courses

--- a/internal/apiserver/apiserver.go
+++ b/internal/apiserver/apiserver.go
@@ -2,11 +2,11 @@ package apiserver
 
 import (
 	"github.com/zhuravlev-pe/course-watch/internal/delivery/http"
-	"github.com/zhuravlev-pe/course-watch/internal/repository/mockrepo"
+	"github.com/zhuravlev-pe/course-watch/internal/delivery/http/v1/fake_authenticator"
+	"github.com/zhuravlev-pe/course-watch/internal/repository/fake_repo"
 	"github.com/zhuravlev-pe/course-watch/internal/server"
 	"github.com/zhuravlev-pe/course-watch/internal/service"
 	"github.com/zhuravlev-pe/course-watch/pkg/idgen"
-	"github.com/zhuravlev-pe/course-watch/pkg/security"
 	"log"
 )
 
@@ -17,17 +17,11 @@ import (
 // @host localhost:8080
 // @BasePath /api/v1/
 
-// @securityDefinitions.apikey AdminAuth
-// @in header
-// @name Authorization
+// @tag.name User
+// @tag.description Managing user account
 
-// @securityDefinitions.apikey StudentsAuth
-// @in header
-// @name Authorization
-
-// @securityDefinitions.apikey UsersAuth
-// @in header
-// @name Authorization
+// @tag.name courses
+// @tag.description Temporary endpoints for Swagger demo. To be removed
 
 // Run initializes whole application.
 func Run() {
@@ -38,16 +32,18 @@ func Run() {
 		log.Fatal(err)
 	}
 
-	repos := mockrepo.New()
+	repos := fake_repo.New()
 
-	jwtHandler := security.NewJwtHandler()
+	//jwtHandler := security.NewJwtHandler()
 	// TODO: first config related task - configure jwtHandler
+
+	fakeBearerAuth := fake_authenticator.New() // to be able to test /user endpoints without logging in
 
 	services := service.NewServices(service.Deps{
 		Repos: repos,
 		IdGen: idGen,
 	})
-	handler := http.NewHandler(services, jwtHandler)
+	handler := http.NewHandler(services, fakeBearerAuth)
 
 	srv := server.NewServer(handler.Init())
 

--- a/internal/core/user.go
+++ b/internal/core/user.go
@@ -1,0 +1,17 @@
+package core
+
+import (
+	"github.com/zhuravlev-pe/course-watch/pkg/security"
+	"time"
+)
+
+type User struct {
+	Id               string
+	Email            string
+	FirstName        string
+	LastName         string
+	DisplayName      string
+	RegistrationDate time.Time
+	HashedPassword   []byte
+	Roles            []security.Role
+}

--- a/internal/delivery/http/handler.go
+++ b/internal/delivery/http/handler.go
@@ -6,20 +6,19 @@ import (
 	ginSwagger "github.com/swaggo/gin-swagger"
 	"github.com/zhuravlev-pe/course-watch/api/swagger"
 	v1 "github.com/zhuravlev-pe/course-watch/internal/delivery/http/v1"
-	"github.com/zhuravlev-pe/course-watch/internal/delivery/http/v1/auth"
 	"github.com/zhuravlev-pe/course-watch/internal/service"
 	"net/http"
 )
 
 type Handler struct {
 	services *service.Services
-	bearer   auth.BearerTokenHandler
+	bearer   v1.BearerAuthenticator
 }
 
-func NewHandler(services *service.Services, jwtHandler auth.BearerTokenHandler) *Handler {
+func NewHandler(services *service.Services, bearer v1.BearerAuthenticator) *Handler {
 	return &Handler{
 		services: services,
-		bearer:   jwtHandler,
+		bearer:   bearer,
 	}
 }
 

--- a/internal/delivery/http/v1/courses.go
+++ b/internal/delivery/http/v1/courses.go
@@ -25,9 +25,9 @@ func (h *Handler) initCoursesRoutes(api *gin.RouterGroup) {
 // @Produce  json
 // @Param id path string true "course id"
 // @Success 200 {object} core.Course
-// @Failure 400,404 {object} response
-// @Failure 500 {object} response
-// @Failure default {object} response
+// @Failure 400,404 {object} utils.Response
+// @Failure 500 {object} utils.Response
+// @Failure default {object} utils.Response
 // @Router /courses/{id} [get]
 func (h *Handler) getCourseById(c *gin.Context) {
 	id := c.Param("id")
@@ -57,8 +57,8 @@ func (h *Handler) getCourseById(c *gin.Context) {
 // @Produce  json
 // @Param input body service.CreateCourseInput true "sign up info"
 // @Success 201 "The generated id is returned in Location header"
-// @Failure 400 {object} response
-// @Failure 500 {object} response
+// @Failure 400 {object} utils.Response
+// @Failure 500 {object} utils.Response
 // @Router /courses/ [post]
 func (h *Handler) create(c *gin.Context) {
 	var input service.CreateCourseInput

--- a/internal/delivery/http/v1/fake_authenticator/fake_authenticator.go
+++ b/internal/delivery/http/v1/fake_authenticator/fake_authenticator.go
@@ -1,0 +1,31 @@
+package fake_authenticator
+
+import (
+	"github.com/gin-gonic/gin"
+	v1 "github.com/zhuravlev-pe/course-watch/internal/delivery/http/v1"
+	"github.com/zhuravlev-pe/course-watch/internal/repository/fake_repo"
+	"github.com/zhuravlev-pe/course-watch/pkg/security"
+)
+
+type fakeBearerAuthenticator struct{}
+
+func New() v1.BearerAuthenticator {
+	return fakeBearerAuthenticator{}
+}
+
+func (f fakeBearerAuthenticator) Authenticate(ctx *gin.Context) {
+	var up security.UserPrincipal
+	up.UserId = fake_repo.SampleUser.Id
+	up.Roles = fake_repo.SampleUser.Roles
+	ctx.Set("user_principal", &up)
+}
+
+func (f fakeBearerAuthenticator) Authorize(_ security.Role) func(ctx *gin.Context) {
+	return func(ctx *gin.Context) {
+		f.Authenticate(ctx)
+	}
+}
+
+func (f fakeBearerAuthenticator) GenerateToken(_ *security.UserPrincipal) (string, error) {
+	return "fake.bearer.token", nil
+}

--- a/internal/delivery/http/v1/handler.go
+++ b/internal/delivery/http/v1/handler.go
@@ -2,20 +2,26 @@ package v1
 
 import (
 	"github.com/gin-gonic/gin"
-	"github.com/zhuravlev-pe/course-watch/internal/delivery/http/v1/auth"
 	"github.com/zhuravlev-pe/course-watch/internal/service"
+	"github.com/zhuravlev-pe/course-watch/pkg/security"
 )
 
 type Handler struct {
 	services *service.Services
-	bearer   auth.BearerTokenHandler
+	bearer   BearerAuthenticator
 	//TODO: logger
 }
 
-func NewHandler(services *service.Services, jwtHandler auth.BearerTokenHandler) *Handler {
+type BearerAuthenticator interface {
+	Authenticate(ctx *gin.Context)
+	Authorize(role security.Role) func(ctx *gin.Context)
+	GenerateToken(principal *security.UserPrincipal) (string, error)
+}
+
+func NewHandler(services *service.Services, bearer BearerAuthenticator) *Handler {
 	return &Handler{
 		services: services,
-		bearer:   jwtHandler,
+		bearer:   bearer,
 	}
 }
 
@@ -23,5 +29,6 @@ func (h *Handler) Init(api *gin.RouterGroup) {
 	v1 := api.Group("/v1")
 	{
 		h.initCoursesRoutes(v1)
+		h.initUserRoutes(v1)
 	}
 }

--- a/internal/delivery/http/v1/user.go
+++ b/internal/delivery/http/v1/user.go
@@ -1,0 +1,90 @@
+package v1
+
+import (
+	"fmt"
+	"github.com/gin-gonic/gin"
+	"github.com/zhuravlev-pe/course-watch/internal/delivery/http/v1/auth"
+	"github.com/zhuravlev-pe/course-watch/internal/delivery/http/v1/utils"
+	"github.com/zhuravlev-pe/course-watch/internal/repository"
+	"github.com/zhuravlev-pe/course-watch/internal/service"
+	"net/http"
+)
+
+func (h *Handler) initUserRoutes(api *gin.RouterGroup) {
+	courses := api.Group("/user", h.bearer.Authenticate)
+	{
+		courses.GET("/", h.getUserInfo)
+		courses.PUT("/", h.updateUserInfo)
+	}
+}
+
+// @Summary Retrieve current user data
+// @Tags User
+// @Description returns info on the currently logged-in user. User_id is extracted from the bearer token
+// @ModuleID getUserInfo
+// @Accept  json
+// @Produce  json
+// @Success 200 {object} service.GetUserInfoOutput
+// @Failure 400,401,404,500 {object} utils.Response
+// @Failure default {object} utils.Response
+// @Router /user/ [get]
+func (h *Handler) getUserInfo(ctx *gin.Context) {
+	up, err := auth.GetAuthenticatedUser(ctx)
+	if err != nil {
+		err = fmt.Errorf("authentication middleware failure: %w", err)
+		utils.ErrorResponseMessageOverride(ctx, http.StatusInternalServerError, err, "user data processing failure")
+		return
+	}
+
+	result, err := h.services.Users.GetUserInfo(ctx.Request.Context(), up.UserId)
+
+	if err != nil {
+		// TODO: discriminate between validation errors, logic errors and internal server errors
+		if err == repository.ErrNotFound {
+			utils.ErrorResponse(ctx, http.StatusNotFound, err)
+			return
+		}
+		utils.ErrorResponse(ctx, http.StatusInternalServerError, err)
+		return
+	}
+	ctx.JSON(http.StatusOK, result)
+}
+
+// @Summary Modify current user data
+// @Tags User
+// @Description modifies user info for the currently logged-in user. User_id is extracted from the bearer token
+// @ModuleID updateUserInfo
+// @Accept  json
+// @Produce  json
+// @Param input body service.UpdateUserInfoInput true "user info"
+// @Success 200
+// @Failure 400,401,404,500 {object} utils.Response
+// @Failure default {object} utils.Response
+// @Router /user/ [put]
+func (h *Handler) updateUserInfo(ctx *gin.Context) {
+	up, err := auth.GetAuthenticatedUser(ctx)
+	if err != nil {
+		err = fmt.Errorf("authentication middleware failure: %w", err)
+		utils.ErrorResponseMessageOverride(ctx, http.StatusInternalServerError, err, "user data processing failure")
+		return
+	}
+	var input service.UpdateUserInfoInput
+	if err = ctx.BindJSON(&input); err != nil {
+		utils.ErrorResponseString(ctx, http.StatusBadRequest, "invalid input body")
+		return
+	}
+
+	err = h.services.Users.UpdateUserInfo(ctx.Request.Context(), up.UserId, &input)
+
+	if err != nil {
+		// TODO: discriminate between validation errors, logic errors and internal server errors
+		if err == repository.ErrNotFound {
+			utils.ErrorResponse(ctx, http.StatusNotFound, err)
+			return
+		}
+		utils.ErrorResponse(ctx, http.StatusInternalServerError, err)
+		return
+	}
+
+	ctx.Status(http.StatusOK)
+}

--- a/internal/delivery/http/v1/utils/response.go
+++ b/internal/delivery/http/v1/utils/response.go
@@ -11,7 +11,7 @@ import "github.com/gin-gonic/gin"
 //	ID interface{} `json:"id"`
 //}
 
-type response struct {
+type Response struct {
 	Message string `json:"message"`
 }
 
@@ -19,17 +19,17 @@ type response struct {
 // TODO: log error data
 func ErrorResponseMessageOverride(c *gin.Context, statusCode int, _ error, message string) {
 	//logger.Error(err)
-	c.AbortWithStatusJSON(statusCode, response{message})
+	c.AbortWithStatusJSON(statusCode, Response{message})
 }
 
 // ErrorResponse aborts the context and sends a properly formatted response with the message from supplied error
 func ErrorResponse(c *gin.Context, statusCode int, err error) {
 	//logger.Error(err)
-	c.AbortWithStatusJSON(statusCode, response{err.Error()})
+	c.AbortWithStatusJSON(statusCode, Response{err.Error()})
 }
 
 // ErrorResponseString aborts the context and sends a properly formatted response with the message from supplied string
 func ErrorResponseString(c *gin.Context, statusCode int, message string) {
 	//logger.Error(message)
-	c.AbortWithStatusJSON(statusCode, response{message})
+	c.AbortWithStatusJSON(statusCode, Response{message})
 }

--- a/internal/repository/fake_repo/courses.go
+++ b/internal/repository/fake_repo/courses.go
@@ -1,4 +1,4 @@
-package mockrepo
+package fake_repo
 
 import (
 	"context"

--- a/internal/repository/fake_repo/repositories.go
+++ b/internal/repository/fake_repo/repositories.go
@@ -1,0 +1,33 @@
+package fake_repo
+
+import (
+	"context"
+	"github.com/zhuravlev-pe/course-watch/internal/core"
+	"github.com/zhuravlev-pe/course-watch/internal/repository"
+	"github.com/zhuravlev-pe/course-watch/pkg/security"
+	"time"
+)
+
+func New() *repository.Repositories {
+	result := &repository.Repositories{
+		Courses: newCourses(),
+		Users:   newUsers(),
+	}
+
+	err := result.Users.Insert(context.Background(), &SampleUser)
+	if err != nil {
+		panic(err)
+	}
+
+	return result
+}
+
+var SampleUser = core.User{
+	Id:               "1582550893222432768",
+	Email:            "doe.j@example.com",
+	FirstName:        "John",
+	LastName:         "Doe",
+	DisplayName:      "JonnyD",
+	RegistrationDate: time.Date(2017, time.July, 21, 17, 32, 28, 0, time.UTC),
+	Roles:            []security.Role{security.Student},
+}

--- a/internal/repository/fake_repo/users.go
+++ b/internal/repository/fake_repo/users.go
@@ -1,0 +1,55 @@
+package fake_repo
+
+import (
+	"context"
+	"errors"
+	"github.com/zhuravlev-pe/course-watch/internal/core"
+	"github.com/zhuravlev-pe/course-watch/internal/repository"
+)
+
+type users struct {
+	byIds map[string]*core.User
+}
+
+func newUsers() repository.Users {
+	return &users{
+		byIds: map[string]*core.User{},
+	}
+}
+
+func (u *users) GetById(ctx context.Context, id string) (*core.User, error) {
+	if ctx.Err() != nil {
+		return nil, ctx.Err()
+	}
+	user, ok := u.byIds[id]
+	if !ok {
+		return nil, repository.ErrNotFound
+	}
+	return user, nil
+}
+
+func (u *users) Insert(ctx context.Context, user *core.User) error {
+	if ctx.Err() != nil {
+		return ctx.Err()
+	}
+	_, ok := u.byIds[user.Id]
+	if ok {
+		return errors.New("user with the specified id already exists")
+	}
+	u.byIds[user.Id] = user
+	return nil
+}
+
+func (u *users) Update(ctx context.Context, id string, input *repository.UpdateUserInput) error {
+	if ctx.Err() != nil {
+		return ctx.Err()
+	}
+	user, ok := u.byIds[id]
+	if !ok {
+		return repository.ErrNotFound
+	}
+	user.FirstName = input.FirstName
+	user.LastName = input.LastName
+	user.DisplayName = input.DisplayName
+	return nil
+}

--- a/internal/repository/mockrepo/repositories.go
+++ b/internal/repository/mockrepo/repositories.go
@@ -1,9 +1,0 @@
-package mockrepo
-
-import "github.com/zhuravlev-pe/course-watch/internal/repository"
-
-func New() *repository.Repositories {
-	return &repository.Repositories{
-		Courses: newCourses(),
-	}
-}

--- a/internal/repository/repositories.go
+++ b/internal/repository/repositories.go
@@ -10,6 +10,19 @@ type Courses interface {
 	Insert(ctx context.Context, course *core.Course) error
 }
 
+type UpdateUserInput struct {
+	FirstName   string
+	LastName    string
+	DisplayName string
+}
+
+type Users interface {
+	GetById(ctx context.Context, id string) (*core.User, error)
+	Insert(ctx context.Context, user *core.User) error
+	Update(ctx context.Context, id string, input *UpdateUserInput) error
+}
+
 type Repositories struct {
 	Courses Courses
+	Users   Users
 }

--- a/internal/service/services.go
+++ b/internal/service/services.go
@@ -5,6 +5,8 @@ import (
 	"github.com/zhuravlev-pe/course-watch/internal/core"
 	"github.com/zhuravlev-pe/course-watch/internal/repository"
 	"github.com/zhuravlev-pe/course-watch/pkg/idgen"
+	"github.com/zhuravlev-pe/course-watch/pkg/security"
+	"time"
 )
 
 type CreateCourseInput struct {
@@ -17,8 +19,30 @@ type Courses interface {
 	Create(ctx context.Context, input CreateCourseInput) (*core.Course, error)
 }
 
+type GetUserInfoOutput struct {
+	Id               string          `json:"id"`
+	Email            string          `json:"email"`
+	FirstName        string          `json:"first_name"`
+	LastName         string          `json:"last_name"`
+	DisplayName      string          `json:"display_name"`
+	RegistrationDate time.Time       `json:"registration_date"`
+	Roles            []security.Role `json:"roles"`
+}
+
+type UpdateUserInfoInput struct {
+	FirstName   string `json:"first_name"`
+	LastName    string `json:"last_name"`
+	DisplayName string `json:"display_name"`
+}
+
+type Users interface {
+	GetUserInfo(ctx context.Context, id string) (*GetUserInfoOutput, error)
+	UpdateUserInfo(ctx context.Context, id string, input *UpdateUserInfoInput) error
+}
+
 type Services struct {
 	Courses Courses
+	Users   Users
 }
 
 type Deps struct {
@@ -28,8 +52,10 @@ type Deps struct {
 
 func NewServices(deps Deps) *Services {
 	coursesService := NewCoursesService(deps.Repos.Courses, deps.IdGen)
+	usersSrv := newUsersService(deps.Repos.Users, deps.IdGen)
 
 	return &Services{
 		Courses: coursesService,
+		Users:   usersSrv,
 	}
 }

--- a/internal/service/users.go
+++ b/internal/service/users.go
@@ -1,0 +1,48 @@
+package service
+
+import (
+	"context"
+	"github.com/zhuravlev-pe/course-watch/internal/repository"
+	"github.com/zhuravlev-pe/course-watch/pkg/idgen"
+)
+
+type usersService struct {
+	repo  repository.Users
+	idGen *idgen.IdGen
+}
+
+func (u *usersService) GetUserInfo(ctx context.Context, id string) (*GetUserInfoOutput, error) {
+	user, err := u.repo.GetById(ctx, id)
+	if err != nil {
+		return nil, err
+	}
+	var result GetUserInfoOutput
+	result.Id = user.Id
+	result.Email = user.Email
+	result.FirstName = user.FirstName
+	result.LastName = user.LastName
+	result.DisplayName = user.DisplayName
+	result.RegistrationDate = user.RegistrationDate
+	result.Roles = user.Roles
+	return &result, nil
+}
+
+func (u *usersService) UpdateUserInfo(ctx context.Context, id string, input *UpdateUserInfoInput) error {
+	//TODO input validation
+	_, err := u.repo.GetById(ctx, id)
+	if err != nil {
+		return err
+	}
+	var upd repository.UpdateUserInput
+	upd.FirstName = input.FirstName
+	upd.LastName = input.LastName
+	upd.DisplayName = input.DisplayName
+	return u.repo.Update(ctx, id, &upd)
+}
+
+func newUsersService(repo repository.Users, idGen *idgen.IdGen) Users {
+	return &usersService{
+		repo:  repo,
+		idGen: idGen,
+	}
+}


### PR DESCRIPTION
This small update introduces /user/ PUT and GET endpoints according to the current (1.0.2) API definition:

https://app.swaggerhub.com/apis/ZHURAVLEVPE/course-watch/1.0.2

The main points:

- core.User type and basic User-related functionality in services and repository are introduced to simplify the work on the authentication endpoints
- the new endpoints further illustrate the overall application structure
- fixed an issue with `response` type which prevented rebuilding the swagger files 

The tests will be added in a separate pull request